### PR TITLE
주소관리 페이지 페이지 로드 실패 수정

### DIFF
--- a/src/app/(mypage)/account-address/addressFlightCard.tsx
+++ b/src/app/(mypage)/account-address/addressFlightCard.tsx
@@ -8,7 +8,6 @@ import DefaultAddressButton from "./defaultAddressButton";
 
 const AddressFlightCard: React.FC<AddressLsitType> = ({ addressList }) => {
   const router = useRouter();
-  console.log(addressList[1].defaultAddress)
 
   //대표주소지 최상위로 표시
   const sortedAddressList = [...addressList].sort((a, b) => {


### PR DESCRIPTION
# 변경점 👍
1. console.log로 인한 페이지 로드 실패 수정을 위하여 해당 코드를 삭제합니다
 
# 비고 ✏
1. 오늘 밤이나 내일 중으로 console.log와 주석을 전부 삭제하려고 합니다.
